### PR TITLE
Replace lxc-snapshot with rsync to improve efficiency. 

### DIFF
--- a/eval-container/checkpoint-restore.sh
+++ b/eval-container/checkpoint-restore.sh
@@ -98,7 +98,7 @@ if [ "$OP" == "restore" ]; then
 	mv db $HOME/.db
 	mv interpose.so $XTERN_ROOT/dync_hook/
 	#sudo rm -rf /dev/shm/*
-	sudo mv dev/shm/* /dev/shm/
+	sudo mv /dev/shm/* /dev/shm/
 	sudo rm -rf dev
 	echo "Restoring $HOME directory file system in the lxc container..."
 	cp filesystem-checkpoint.patch $HOME
@@ -108,10 +108,15 @@ if [ "$OP" == "restore" ]; then
 	sudo lxc-stop -n $CONTAINER
 	sleep 1
 	echo "Restoring base file system in $FS_BASE_DIR, may take a few minutes..."
-	sudo lxc-snapshot -n $CONTAINER -r base
+	# sudo lxc-snapshot -n $CONTAINER -r base
+	# some modifications here to improve speed...
+	echo "Rsync config file:"
+	cat rsync_exclude.txt
+	sudo rsync -avzh --delete --exclude-from=rsync_exclude.txt /var/lib/lxc/u1/snaps/base/rootfs$HOME /var/lib/lxc/u1/rootfs/home
 	#sync
 	echo "Restoring current file system to the checkpoint moment, may take a few seconds..."
 	sudo patch -d $SNAPS_DIR/../rootfs/$HOME -p1 < $HOME/filesystem-checkpoint.patch
+	echo 'Patching complete. '
 
 # Resume process and the container.
 	#sync
@@ -166,4 +171,3 @@ if [ "$OP" == "restore" ]; then
 		echo "> sudo lxc-attach -n $CONTAINER -- ps -e | grep $PROG_NAME"
 	fi
 fi
-

--- a/eval-container/collect-scheds.sh
+++ b/eval-container/collect-scheds.sh
@@ -40,16 +40,13 @@ process_host
 HOST="bug02"
 process_host
 
-#cd scheds
-#for f in *.log
-#do
-#	echo "Truncating $f after line $LINE (the last close() operation)..."
-#	sed -i '$LINE,$ d' $f
-#done
-#cd ..
+cd scheds
+for f in *.log
+do
+	echo "Truncating $f after line $LINE (the last close() operation)..."
+	sed -i "$LINE,$ d" $f
+	echo "number of lines: $(wc -l < $f)"
+done
 
-echo ""
-echo ""
-echo "Please truncate all files in the scheds directory with this line number: $LINE"
-echo "Command to do so: cd scheds; ls . | xargs sed -i '$LINE,$ d'"
+cd ..
 

--- a/eval-container/rsync_exclude.txt
+++ b/eval-container/rsync_exclude.txt
@@ -1,0 +1,9 @@
+*/.bash_history
+*/dump.options
+*/local.options
+*/xtern
+*/libevent_paxos
+*/eval
+*/tools
+*/eval-container
+*/eval-multiMachine


### PR DESCRIPTION
I've replaced lxc-snapshot with rsync in file eval-container/checkpoint-restore.sh. 
